### PR TITLE
Add BoujeeBot concierge widget and chat APIs

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,0 +1,66 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export const runtime = "edge";
+
+const SYSTEM_PROMPT = `You are "BoujeeBot" — Ahmed’s AI concierge for UAE travel. Your style: smart, no-BS, warm, and high-energy.
+You must:
+- Build clean, vivid day-by-day itineraries (Day 1, Day 2…); include 1 short "Pro-Tip" per itinerary. Default pro-tip: "Remember to stay hydrated, especially during daytime excursions. It's the key to enjoying the UAE's climate to the fullest."
+- Collect and confirm trip inputs when missing: dates, pax, budget, interests, vibe (adventure, luxury, family, chill), pickup area.
+- Offer specific UAE experiences (desert safari, buggy rides, Dubai/Abu Dhabi city tours, dhow cruises, yachts, helicopter, hot air balloon, theme parks, Louvre Abu Dhabi, Museum of the Future, etc.).
+- Be concise, friendly, and solution-oriented. Use bullets. Avoid fluff.
+- Lead-gen goal: politely ask for visitor’s **WhatsApp number** and name; confirm consent for follow-up. If provided, summarize details cleanly for CRM.
+- Never make promises about availability or pricing; say you’ll “check and confirm.”
+- If the user asks for cancellations/refunds, say you’ll email the support desk and follow company SOPs.
+- Respect cultural etiquette for mosque visits (modest dress).
+- Don’t use disclaimers like “as an AI.” Stay human and confident.
+`;
+
+export async function POST(req: NextRequest) {
+  try {
+    const { messages, lead } = await req.json();
+    const apiKey = process.env.OPENAI_API_KEY;
+
+    if (!apiKey) {
+      return NextResponse.json(
+        { error: "Missing OPENAI_API_KEY" },
+        { status: 500 }
+      );
+    }
+
+    const body = {
+      model: "gpt-5.1-mini",
+      messages: [
+        { role: "system", content: SYSTEM_PROMPT },
+        lead
+          ? { role: "system", content: `Lead context: ${JSON.stringify(lead)}` }
+          : null,
+        ...(messages ?? []),
+      ].filter(Boolean),
+      temperature: 0.7,
+    };
+
+    const r = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!r.ok) {
+      const t = await r.text();
+      return NextResponse.json({ error: t }, { status: 500 });
+    }
+
+    const data = await r.json();
+    const text = data.choices?.[0]?.message?.content || "";
+
+    return NextResponse.json({ reply: text });
+  } catch (e: any) {
+    return NextResponse.json(
+      { error: e?.message || "Unknown error" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/lead/route.ts
+++ b/app/api/lead/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export const runtime = "edge";
+
+export async function POST(req: NextRequest) {
+  try {
+    const lead = await req.json();
+
+    // TODO: Replace with your persistence (Airtable/HubSpot/Notion/Vercel KV/Webhook)
+    // Example: await fetch("https://hooks.zapier.com/hooks/catch/...", {
+    //   method: "POST",
+    //   body: JSON.stringify(lead),
+    // });
+
+    return NextResponse.json({ ok: true, received: lead });
+  } catch (e: any) {
+    return NextResponse.json(
+      { ok: false, error: e?.message || "Unknown error" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,9 @@
+import BoujeeBot from "@/components/BoujeeBot";
+
+export default function Home() {
+  return (
+    <main className="min-h-screen">
+      <BoujeeBot />
+    </main>
+  );
+}

--- a/components/BoujeeBot.tsx
+++ b/components/BoujeeBot.tsx
@@ -1,0 +1,280 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+
+type ChatMessage = { role: "user" | "assistant"; content: string };
+
+type Lead = {
+  name?: string;
+  whatsapp?: string;
+  email?: string;
+  trip?: {
+    dates?: string;
+    pax?: string;
+    budget?: string;
+    interests?: string[];
+    vibe?: string;
+    pickupArea?: string;
+  };
+  consent?: boolean;
+};
+
+export default function BoujeeBot() {
+  const [open, setOpen] = useState(false);
+  const [input, setInput] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [messages, setMessages] = useState<ChatMessage[]>([
+    {
+      role: "assistant",
+      content:
+        "Hey, I’m BoujeeBot — Ahmed’s AI concierge. Want me to sketch a UAE itinerary or swap WhatsApp so Ahmed can tailor everything for you?",
+    },
+  ]);
+  const [lead, setLead] = useState<Lead>({ trip: {} });
+  const listRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    listRef.current?.scrollTo({
+      top: listRef.current.scrollHeight,
+      behavior: "smooth",
+    });
+  }, [messages, open]);
+
+  const whatsappBusiness = process.env.NEXT_PUBLIC_WHATSAPP_BUSINESS || "";
+
+  const waLink = useMemo(() => {
+    if (!lead.whatsapp) return null;
+
+    const pre = encodeURIComponent(
+      `Hi Ahmed, I shared my details with BoujeeBot. Name: ${lead.name || ""}, Dates: ${lead.trip?.dates || ""}, Pax: ${lead.trip?.pax || ""}, Interests: ${(lead.trip?.interests || []).join(", ")}`
+    );
+
+    return `https://wa.me/${whatsappBusiness}?text=${pre}`;
+  }, [lead.whatsapp, lead.name, lead.trip, whatsappBusiness]);
+
+  async function sendMessage(text: string) {
+    const userMsg: ChatMessage = { role: "user", content: text };
+    setMessages((m) => [...m, userMsg]);
+    setInput("");
+    setLoading(true);
+
+    try {
+      const r = await fetch("/api/chat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ messages: [...messages, userMsg], lead }),
+      });
+      const data = await r.json();
+      const reply: ChatMessage = {
+        role: "assistant",
+        content: data.reply || "(no reply)",
+      };
+      setMessages((m) => [...m, reply]);
+    } catch (e) {
+      setMessages((m) => [
+        ...m,
+        { role: "assistant", content: "Hmm… had a hiccup. Try again in a sec." },
+      ]);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function submitLead() {
+    try {
+      const payload = { ...lead, collectedAt: new Date().toISOString() };
+      await fetch("/api/lead", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+
+      setMessages((m) => [
+        ...m,
+        {
+          role: "assistant",
+          content:
+            "Got it — I’ll share this with Ahmed. Want me to draft a 1-day sample itinerary now?",
+        },
+      ]);
+    } catch (e) {
+      setMessages((m) => [
+        ...m,
+        {
+          role: "assistant",
+          content: "Couldn’t save lead just now, but I kept it in our chat. Try again soon.",
+        },
+      ]);
+    }
+  }
+
+  const quickActions = [
+    { label: "Plan my UAE trip", value: "Plan my trip" },
+    { label: "Share WhatsApp", value: "Here’s my WhatsApp number" },
+    { label: "Best desert safari combo", value: "Recommend a desert safari combo" },
+  ];
+
+  return (
+    <>
+      <div className="fixed bottom-5 right-5 z-50">
+        <button
+          onClick={() => setOpen((o) => !o)}
+          className="rounded-full shadow-lg px-4 py-3 text-white bg-black/90 hover:bg-black"
+        >
+          {open ? "Close BoujeeBot" : "Chat with BoujeeBot"}
+        </button>
+      </div>
+
+      {open && (
+        <div className="fixed bottom-20 right-5 w-96 max-w-[95vw] h-[560px] bg-white border rounded-2xl shadow-2xl flex flex-col overflow-hidden">
+          <div className="p-4 border-b bg-gradient-to-r from-black to-stone-800 text-white">
+            <div className="font-semibold">BoujeeBot — Ahmed’s AI concierge</div>
+            <div className="text-xs opacity-80">Itineraries • WhatsApp leads • Zero fluff</div>
+          </div>
+
+          <div className="p-3 grid grid-cols-2 gap-2 text-xs border-b">
+            <input
+              placeholder="Your name"
+              className="border rounded-lg px-2 py-2"
+              value={lead.name || ""}
+              onChange={(e) => setLead((s) => ({ ...s, name: e.target.value }))}
+            />
+            <input
+              placeholder="WhatsApp (e.g., 9715XXXXXXX)"
+              className="border rounded-lg px-2 py-2"
+              value={lead.whatsapp || ""}
+              onChange={(e) =>
+                setLead((s) => ({ ...s, whatsapp: e.target.value }))
+              }
+            />
+            <input
+              placeholder="Dates (e.g., 20–24 Nov)"
+              className="border rounded-lg px-2 py-2 col-span-2"
+              value={lead.trip?.dates || ""}
+              onChange={(e) =>
+                setLead((s) => ({ ...s, trip: { ...s.trip, dates: e.target.value } }))
+              }
+            />
+            <div className="grid grid-cols-3 gap-2 col-span-2">
+              <input
+                placeholder="Pax"
+                className="border rounded-lg px-2 py-2"
+                value={lead.trip?.pax || ""}
+                onChange={(e) =>
+                  setLead((s) => ({ ...s, trip: { ...s.trip, pax: e.target.value } }))
+                }
+              />
+              <input
+                placeholder="Budget (AED)"
+                className="border rounded-lg px-2 py-2"
+                value={lead.trip?.budget || ""}
+                onChange={(e) =>
+                  setLead((s) => ({ ...s, trip: { ...s.trip, budget: e.target.value } }))
+                }
+              />
+              <input
+                placeholder="Vibe (luxury/adventure…)"
+                className="border rounded-lg px-2 py-2"
+                value={lead.trip?.vibe || ""}
+                onChange={(e) =>
+                  setLead((s) => ({ ...s, trip: { ...s.trip, vibe: e.target.value } }))
+                }
+              />
+            </div>
+            <input
+              placeholder="Interests (comma-separated)"
+              className="border rounded-lg px-2 py-2 col-span-2"
+              value={(lead.trip?.interests || []).join(", ")}
+              onChange={(e) =>
+                setLead((s) => ({
+                  ...s,
+                  trip: {
+                    ...s.trip,
+                    interests: e.target.value
+                      .split(",")
+                      .map((v) => v.trim())
+                      .filter(Boolean),
+                  },
+                }))
+              }
+            />
+            <div className="flex items-center gap-2 col-span-2">
+              <input
+                type="checkbox"
+                id="consent"
+                checked={!!lead.consent}
+                onChange={(e) =>
+                  setLead((s) => ({ ...s, consent: e.target.checked }))
+                }
+              />
+              <label htmlFor="consent">I agree to be contacted on WhatsApp</label>
+              <button
+                onClick={submitLead}
+                className="ml-auto text-xs px-3 py-2 border rounded-lg hover:bg-black hover:text-white"
+              >
+                Save
+              </button>
+              {waLink && (
+                <a
+                  href={waLink}
+                  target="_blank"
+                  className="text-xs px-3 py-2 border rounded-lg hover:bg-black hover:text-white"
+                >
+                  Open WhatsApp
+                </a>
+              )}
+            </div>
+          </div>
+
+          <div ref={listRef} className="flex-1 overflow-auto p-3 space-y-3">
+            {messages.map((m, i) => (
+              <div
+                key={i}
+                className={
+                  m.role === "assistant"
+                    ? "text-sm bg-stone-100 p-2 rounded-xl"
+                    : "text-sm bg-black text-white p-2 rounded-xl ml-auto w-fit"
+                }
+              >
+                {m.content}
+              </div>
+            ))}
+          </div>
+
+          <div className="px-3 pb-2 flex gap-2 flex-wrap border-t">
+            {quickActions.map((qa) => (
+              <button
+                key={qa.label}
+                onClick={() => sendMessage(qa.value)}
+                className="text-xs px-3 py-2 border rounded-full hover:bg-stone-100"
+              >
+                {qa.label}
+              </button>
+            ))}
+          </div>
+
+          <div className="p-3 border-t flex gap-2">
+            <input
+              className="flex-1 border rounded-xl px-3 py-2"
+              placeholder="Tell me dates, pax, vibe…"
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && input.trim()) {
+                  sendMessage(input.trim());
+                }
+              }}
+            />
+            <button
+              disabled={loading || !input.trim()}
+              onClick={() => sendMessage(input.trim())}
+              className="px-4 py-2 rounded-xl bg-black text-white disabled:opacity-30"
+            >
+              {loading ? "…" : "Send"}
+            </button>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add BoujeeBot concierge chat widget component with lead capture form and WhatsApp handoff link
- create chat completion API route using the BoujeeBot system prompt and OpenAI API
- add lead capture API endpoint scaffold and include widget on the homepage

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0d46ca244832185dd185fcf9fd024