### PR TITLE
Refactor deploy to Netlify functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+node_modules/
+.next/
+out/
+.env.local
+
+# Debug logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# Local Netlify data
+.netlify/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
 # DXBiti
+
+This project contains the BoujeeBot concierge widget and supporting Netlify Functions for chat completions and lead capture.
+
+## Getting started
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Create a `.env.local` file with your OpenAI key (and optional WhatsApp number):
+   ```bash
+   OPENAI_API_KEY=your_openai_api_key
+   NEXT_PUBLIC_WHATSAPP_BUSINESS=9715XXXXXXX
+   ```
+3. Run the development server with Netlify Functions emulation:
+   ```bash
+   npx netlify dev
+   ```
+
+## Deployment notes
+
+- Netlify’s UI build command may be locked to `gatsby build`. A lightweight shim is included so the command simply runs `npm run build`, which executes `next build && next export`.
+- Functions live in `netlify/functions`. They expose the chat completion and lead capture endpoints at `/.netlify/functions/chat` and `/.netlify/functions/lead`.
+- The static site output is generated in the `out` directory.

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,14 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-sans, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif);
+  background-color: #f7f7f7;
+  color: #111;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from "next";
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "BoujeeBot Concierge",
+  description: "AI Boujee Detours & No-BS Travel Hacks",
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,9 @@
+import BoujeeBot from "@/components/BoujeeBot";
+
+export default function Home() {
+  return (
+    <main className="min-h-screen">
+      <BoujeeBot />
+    </main>
+  );
+}

--- a/components/BoujeeBot.tsx
+++ b/components/BoujeeBot.tsx
@@ -1,0 +1,290 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+
+type ChatMessage = { role: "user" | "assistant"; content: string };
+
+type Lead = {
+  name?: string;
+  whatsapp?: string;
+  email?: string;
+  trip?: {
+    dates?: string;
+    pax?: string;
+    budget?: string;
+    interests?: string[];
+    vibe?: string;
+    pickupArea?: string;
+  };
+  consent?: boolean;
+};
+
+export default function BoujeeBot() {
+  const [open, setOpen] = useState(false);
+  const [input, setInput] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [messages, setMessages] = useState<ChatMessage[]>([
+    {
+      role: "assistant",
+      content:
+        "Hey, I’m BoujeeBot — Ahmed’s AI concierge. Want me to sketch a UAE itinerary or swap WhatsApp so Ahmed can tailor everything for you?",
+    },
+  ]);
+  const [lead, setLead] = useState<Lead>({ trip: {} });
+  const listRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    listRef.current?.scrollTo({
+      top: listRef.current.scrollHeight,
+      behavior: "smooth",
+    });
+  }, [messages, open]);
+
+  const whatsappBusiness = process.env.NEXT_PUBLIC_WHATSAPP_BUSINESS || "";
+  const chatEndpoint =
+    process.env.NEXT_PUBLIC_CHAT_ENDPOINT || "/.netlify/functions/chat";
+  const leadEndpoint =
+    process.env.NEXT_PUBLIC_LEAD_ENDPOINT || "/.netlify/functions/lead";
+
+  const waLink = useMemo(() => {
+    if (!lead.whatsapp) return null;
+
+    const pre = encodeURIComponent(
+      `Hi Ahmed, I shared my details with BoujeeBot. Name: ${lead.name || ""}, Dates: ${lead.trip?.dates || ""}, Pax: ${lead.trip?.pax || ""}, Interests: ${(lead.trip?.interests || []).join(", ")}`
+    );
+
+    return `https://wa.me/${whatsappBusiness}?text=${pre}`;
+  }, [lead.whatsapp, lead.name, lead.trip, whatsappBusiness]);
+
+  async function sendMessage(text: string) {
+    const userMsg: ChatMessage = { role: "user", content: text };
+    setMessages((m) => [...m, userMsg]);
+    setInput("");
+    setLoading(true);
+
+    try {
+      const r = await fetch(chatEndpoint, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ messages: [...messages, userMsg], lead }),
+      });
+      if (!r.ok) {
+        throw new Error("Chat request failed");
+      }
+      const data = await r.json();
+      const reply: ChatMessage = {
+        role: "assistant",
+        content: data.reply || "(no reply)",
+      };
+      setMessages((m) => [...m, reply]);
+    } catch (e) {
+      setMessages((m) => [
+        ...m,
+        { role: "assistant", content: "Hmm… had a hiccup. Try again in a sec." },
+      ]);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function submitLead() {
+    try {
+      const payload = { ...lead, collectedAt: new Date().toISOString() };
+      const r = await fetch(leadEndpoint, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      if (!r.ok) {
+        throw new Error("Lead request failed");
+      }
+
+      setMessages((m) => [
+        ...m,
+        {
+          role: "assistant",
+          content:
+            "Got it — I’ll share this with Ahmed. Want me to draft a 1-day sample itinerary now?",
+        },
+      ]);
+    } catch (e) {
+      setMessages((m) => [
+        ...m,
+        {
+          role: "assistant",
+          content: "Couldn’t save lead just now, but I kept it in our chat. Try again soon.",
+        },
+      ]);
+    }
+  }
+
+  const quickActions = [
+    { label: "Plan my UAE trip", value: "Plan my trip" },
+    { label: "Share WhatsApp", value: "Here’s my WhatsApp number" },
+    { label: "Best desert safari combo", value: "Recommend a desert safari combo" },
+  ];
+
+  return (
+    <>
+      <div className="fixed bottom-5 right-5 z-50">
+        <button
+          onClick={() => setOpen((o) => !o)}
+          className="rounded-full shadow-lg px-4 py-3 text-white bg-black/90 hover:bg-black"
+        >
+          {open ? "Close BoujeeBot" : "Chat with BoujeeBot"}
+        </button>
+      </div>
+
+      {open && (
+        <div className="fixed bottom-20 right-5 w-96 max-w-[95vw] h-[560px] bg-white border rounded-2xl shadow-2xl flex flex-col overflow-hidden">
+          <div className="p-4 border-b bg-gradient-to-r from-black to-stone-800 text-white">
+            <div className="font-semibold">BoujeeBot — Ahmed’s AI concierge</div>
+            <div className="text-xs opacity-80">Itineraries • WhatsApp leads • Zero fluff</div>
+          </div>
+
+          <div className="p-3 grid grid-cols-2 gap-2 text-xs border-b">
+            <input
+              placeholder="Your name"
+              className="border rounded-lg px-2 py-2"
+              value={lead.name || ""}
+              onChange={(e) => setLead((s) => ({ ...s, name: e.target.value }))}
+            />
+            <input
+              placeholder="WhatsApp (e.g., 9715XXXXXXX)"
+              className="border rounded-lg px-2 py-2"
+              value={lead.whatsapp || ""}
+              onChange={(e) =>
+                setLead((s) => ({ ...s, whatsapp: e.target.value }))
+              }
+            />
+            <input
+              placeholder="Dates (e.g., 20–24 Nov)"
+              className="border rounded-lg px-2 py-2 col-span-2"
+              value={lead.trip?.dates || ""}
+              onChange={(e) =>
+                setLead((s) => ({ ...s, trip: { ...s.trip, dates: e.target.value } }))
+              }
+            />
+            <div className="grid grid-cols-3 gap-2 col-span-2">
+              <input
+                placeholder="Pax"
+                className="border rounded-lg px-2 py-2"
+                value={lead.trip?.pax || ""}
+                onChange={(e) =>
+                  setLead((s) => ({ ...s, trip: { ...s.trip, pax: e.target.value } }))
+                }
+              />
+              <input
+                placeholder="Budget (AED)"
+                className="border rounded-lg px-2 py-2"
+                value={lead.trip?.budget || ""}
+                onChange={(e) =>
+                  setLead((s) => ({ ...s, trip: { ...s.trip, budget: e.target.value } }))
+                }
+              />
+              <input
+                placeholder="Vibe (luxury/adventure…)"
+                className="border rounded-lg px-2 py-2"
+                value={lead.trip?.vibe || ""}
+                onChange={(e) =>
+                  setLead((s) => ({ ...s, trip: { ...s.trip, vibe: e.target.value } }))
+                }
+              />
+            </div>
+            <input
+              placeholder="Interests (comma-separated)"
+              className="border rounded-lg px-2 py-2 col-span-2"
+              value={(lead.trip?.interests || []).join(", ")}
+              onChange={(e) =>
+                setLead((s) => ({
+                  ...s,
+                  trip: {
+                    ...s.trip,
+                    interests: e.target.value
+                      .split(",")
+                      .map((v) => v.trim())
+                      .filter(Boolean),
+                  },
+                }))
+              }
+            />
+            <div className="flex items-center gap-2 col-span-2">
+              <input
+                type="checkbox"
+                id="consent"
+                checked={!!lead.consent}
+                onChange={(e) =>
+                  setLead((s) => ({ ...s, consent: e.target.checked }))
+                }
+              />
+              <label htmlFor="consent">I agree to be contacted on WhatsApp</label>
+              <button
+                onClick={submitLead}
+                className="ml-auto text-xs px-3 py-2 border rounded-lg hover:bg-black hover:text-white"
+              >
+                Save
+              </button>
+              {waLink && (
+                <a
+                  href={waLink}
+                  target="_blank"
+                  className="text-xs px-3 py-2 border rounded-lg hover:bg-black hover:text-white"
+                >
+                  Open WhatsApp
+                </a>
+              )}
+            </div>
+          </div>
+
+          <div ref={listRef} className="flex-1 overflow-auto p-3 space-y-3">
+            {messages.map((m, i) => (
+              <div
+                key={i}
+                className={
+                  m.role === "assistant"
+                    ? "text-sm bg-stone-100 p-2 rounded-xl"
+                    : "text-sm bg-black text-white p-2 rounded-xl ml-auto w-fit"
+                }
+              >
+                {m.content}
+              </div>
+            ))}
+          </div>
+
+          <div className="px-3 pb-2 flex gap-2 flex-wrap border-t">
+            {quickActions.map((qa) => (
+              <button
+                key={qa.label}
+                onClick={() => sendMessage(qa.value)}
+                className="text-xs px-3 py-2 border rounded-full hover:bg-stone-100"
+              >
+                {qa.label}
+              </button>
+            ))}
+          </div>
+
+          <div className="p-3 border-t flex gap-2">
+            <input
+              className="flex-1 border rounded-xl px-3 py-2"
+              placeholder="Tell me dates, pax, vibe…"
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && input.trim()) {
+                  sendMessage(input.trim());
+                }
+              }}
+            />
+            <button
+              disabled={loading || !input.trim()}
+              onClick={() => sendMessage(input.trim())}
+              className="px-4 py-2 rounded-xl bg-black text-white disabled:opacity-30"
+            >
+              {loading ? "…" : "Send"}
+            </button>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,6 @@
+[build]
+  command = "npm run build"
+  publish = "out"
+
+[build.environment]
+  NETLIFY_SKIP_INSTALL_PLUGINS = "true"

--- a/netlify/functions/chat.ts
+++ b/netlify/functions/chat.ts
@@ -1,0 +1,83 @@
+const SYSTEM_PROMPT = `You are “BoujeeBot” — Ahmed’s AI concierge for UAE travel. Your style: smart, no-BS, warm, and high-energy.
+You must:
+- Build clean, vivid day-by-day itineraries (Day 1, Day 2…); include 1 short "Pro-Tip" per itinerary. Default pro-tip: "Remember to stay hydrated, especially during daytime excursions. It's the key to enjoying the UAE's climate to the fullest."
+- Collect and confirm trip inputs when missing: dates, pax, budget, interests, vibe (adventure, luxury, family, chill), pickup area.
+- Offer specific UAE experiences (desert safari, buggy rides, Dubai/Abu Dhabi city tours, dhow cruises, yachts, helicopter, hot air balloon, theme parks, Louvre Abu Dhabi, Museum of the Future, etc.).
+- Be concise, friendly, and solution-oriented. Use bullets. Avoid fluff.
+- Lead-gen goal: politely ask for visitor’s WhatsApp number and name; confirm consent for follow-up. If provided, summarize details cleanly for CRM.
+- Never make promises about availability or pricing; say you’ll “check and confirm.”
+- If the user asks for cancellations/refunds, say you’ll email the support desk and follow company SOPs.
+- Respect cultural etiquette for mosque visits (modest dress).
+- Don’t use disclaimers like “as an AI.” Stay human and confident.`;
+
+type NetlifyEvent = {
+  httpMethod: string;
+  body: string | null;
+};
+
+type NetlifyResponse = {
+  statusCode: number;
+  body: string;
+  headers?: Record<string, string>;
+};
+
+export const handler = async (event: NetlifyEvent): Promise<NetlifyResponse> => {
+  if (event.httpMethod !== "POST") {
+    return {
+      statusCode: 405,
+      body: JSON.stringify({ error: "Method not allowed" }),
+    };
+  }
+
+  try {
+    const { messages, lead } = JSON.parse(event.body ?? "{}");
+    const apiKey = process.env.OPENAI_API_KEY;
+
+    if (!apiKey) {
+      return {
+        statusCode: 500,
+        body: JSON.stringify({ error: "Missing OPENAI_API_KEY" }),
+      };
+    }
+
+    const body = {
+      model: "gpt-5.1-mini",
+      messages: [
+        { role: "system", content: SYSTEM_PROMPT },
+        lead ? { role: "system", content: `Lead context: ${JSON.stringify(lead)}` } : null,
+        ...(messages ?? []),
+      ].filter(Boolean),
+      temperature: 0.7,
+    };
+
+    const response = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      return {
+        statusCode: 500,
+        body: JSON.stringify({ error: text }),
+      };
+    }
+
+    const data = await response.json();
+    const text = data.choices?.[0]?.message?.content || "";
+
+    return {
+      statusCode: 200,
+      body: JSON.stringify({ reply: text }),
+    };
+  } catch (error) {
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ error: error instanceof Error ? error.message : "Unknown error" }),
+    };
+  }
+};

--- a/netlify/functions/lead.ts
+++ b/netlify/functions/lead.ts
@@ -1,0 +1,36 @@
+type NetlifyEvent = {
+  httpMethod: string;
+  body: string | null;
+};
+
+type NetlifyResponse = {
+  statusCode: number;
+  body: string;
+};
+
+export const handler = async (event: NetlifyEvent): Promise<NetlifyResponse> => {
+  if (event.httpMethod !== "POST") {
+    return {
+      statusCode: 405,
+      body: JSON.stringify({ ok: false, error: "Method not allowed" }),
+    };
+  }
+
+  try {
+    const lead = JSON.parse(event.body ?? "{}");
+
+    // TODO: Replace with CRM/Airtable/HubSpot/etc. webhook or storage of your choice.
+    return {
+      statusCode: 200,
+      body: JSON.stringify({ ok: true, received: lead }),
+    };
+  } catch (error) {
+    return {
+      statusCode: 500,
+      body: JSON.stringify({
+        ok: false,
+        error: error instanceof Error ? error.message : "Unknown error",
+      }),
+    };
+  }
+};

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,8 @@
+const nextConfig = {
+  output: "export",
+  images: {
+    unoptimized: true,
+  },
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "dxbiti",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build && next export",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.2.5",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  },
+  "devDependencies": {
+    "@types/node": "20.16.5",
+    "@types/react": "18.3.4",
+    "@types/react-dom": "18.3.2",
+    "autoprefixer": "10.4.19",
+    "postcss": "8.4.39",
+    "tailwindcss": "3.4.10",
+    "typescript": "5.5.4"
+  },
+  "bin": {
+    "gatsby": "./scripts/gatsby.js"
+  }
+}

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,0 +1,8 @@
+const config = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};
+
+export default config;

--- a/scripts/gatsby.js
+++ b/scripts/gatsby.js
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+const { spawnSync } = require("node:child_process");
+
+const args = process.argv.slice(2);
+
+if (args[0] === "build") {
+  const result = spawnSync("npm", ["run", "build"], {
+    stdio: "inherit",
+    shell: process.platform === "win32",
+  });
+  process.exit(result.status ?? 0);
+}
+
+console.error(
+  `Unsupported Gatsby command: ${args.join(" ") || "(none)"}. This project uses Next.js; try \"npm run build\" instead.`
+);
+process.exit(1);

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,11 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: ["./app/**/*.{js,ts,jsx,tsx}", "./components/**/*.{js,ts,jsx,tsx}"],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};
+
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["node"],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- replace the Next.js API routes with Netlify Functions and point the BoujeeBot widget to the function endpoints
- scaffold a minimal Next.js + Tailwind setup that exports static assets for deployment and add a Gatsby build shim for locked Netlify commands
- document local setup, deployment notes, and update Netlify configuration and ignores for the new build output

## Testing
- npm install *(fails: registry access is restricted in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0d46ca244832185dd185fcf9fd024