### PR TITLE
Clean up chat route and improve error handling

### DIFF
--- a/.github/workflows/gatsby.yml
+++ b/.github/workflows/gatsby.yml
@@ -42,20 +42,37 @@ jobs:
           if [ -f "${{ github.workspace }}/yarn.lock" ]; then
             echo "manager=yarn" >> $GITHUB_OUTPUT
             echo "command=install" >> $GITHUB_OUTPUT
+            echo "cache=yarn" >> $GITHUB_OUTPUT
+            echo "cache-dependency-path=yarn.lock" >> $GITHUB_OUTPUT
+            exit 0
+          elif [ -f "${{ github.workspace }}/package-lock.json" ]; then
+            echo "manager=npm" >> $GITHUB_OUTPUT
+            echo "command=ci" >> $GITHUB_OUTPUT
+            echo "cache=npm" >> $GITHUB_OUTPUT
+            echo "cache-dependency-path=package-lock.json" >> $GITHUB_OUTPUT
             exit 0
           elif [ -f "${{ github.workspace }}/package.json" ]; then
             echo "manager=npm" >> $GITHUB_OUTPUT
-            echo "command=ci" >> $GITHUB_OUTPUT
+            echo "command=install" >> $GITHUB_OUTPUT
+            echo "cache=none" >> $GITHUB_OUTPUT
+            echo "cache-dependency-path=" >> $GITHUB_OUTPUT
             exit 0
           else
             echo "Unable to determine package manager"
             exit 1
           fi
-      - name: Setup Node
+      - name: Setup Node (with cache)
+        if: ${{ steps.detect-package-manager.outputs.cache != 'none' }}
         uses: actions/setup-node@v4
         with:
           node-version: "20"
-          cache: ${{ steps.detect-package-manager.outputs.manager }}
+          cache: ${{ steps.detect-package-manager.outputs.cache }}
+          cache-dependency-path: ${{ steps.detect-package-manager.outputs.cache-dependency-path }}
+      - name: Setup Node (no cache)
+        if: ${{ steps.detect-package-manager.outputs.cache == 'none' }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v5

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,68 +1,68 @@
 import { NextRequest, NextResponse } from "next/server";
-export const runtime = "edge"; // Vercel Edge Runtime for speed
-// Core system prompt — BoujeeBot’s brain
-const SYSTEM_PROMPT = `You are “BoujeeBot” — Ahmed’s AI concierge for UAE
-travel. Your style: smart, no‑BS, warm, and high‑energy.
+
+export const runtime = "edge";
+
+const SYSTEM_PROMPT = `You are "BoujeeBot" — Ahmed's AI concierge for UAE travel.
+Your style is smart, no-BS, warm, and high-energy.
 You must:
-- Build clean, vivid day‑by‑day itineraries (Day 1, Day 2…); include 1 short
-"Pro‑Tip" per itinerary. Default pro‑tip: "Remember to stay hydrated, especially
-during daytime excursions. It's the key to enjoying the UAE's climate to the
-fullest."
-- Collect and confirm trip inputs when missing: dates, pax, budget, interests,
-•
-•
-1
-vibe (adventure, luxury, family, chill), pickup area.
-- Offer specific UAE experiences (desert safari, buggy rides, Dubai/Abu Dhabi
-city tours, dhow cruises, yachts, helicopter, hot air balloon, theme parks,
-Louvre Abu Dhabi, Museum of the Future, etc.).
-- Be concise, friendly, and solution‑oriented. Use bullets. Avoid fluff.
-- Lead‑gen goal: politely ask for visitor’s **WhatsApp number** and name;
-confirm consent for follow‑up. If provided, summarize details cleanly for CRM.
-- Never make promises about availability or pricing; say you’ll “check and
-confirm.”
-- If the user asks for cancellations/refunds, say you’ll email the support desk
-and follow company SOPs.
+- Build clean, vivid day-by-day itineraries (Day 1, Day 2, …); include one short "Pro-Tip" per itinerary. The default pro-tip is: "Remember to stay hydrated, especially during daytime excursions. It's the key to enjoying the UAE's climate to the fullest."
+- Collect and confirm trip inputs when missing: dates, pax, budget, interests, vibe (adventure, luxury, family, chill), pickup area.
+- Offer specific UAE experiences (desert safari, buggy rides, Dubai/Abu Dhabi city tours, dhow cruises, yachts, helicopter, hot air balloon, theme parks, Louvre Abu Dhabi, Museum of the Future, etc.).
+- Be concise, friendly, and solution-oriented. Use bullets. Avoid fluff.
+- Lead-gen goal: politely ask for the visitor's WhatsApp number and name; confirm consent for follow-up. If provided, summarize details cleanly for CRM.
+- Never make promises about availability or pricing; say you'll “check and confirm.”
+- If the user asks for cancellations/refunds, say you'll email the support desk and follow company SOPs.
 - Respect cultural etiquette for mosque visits (modest dress).
-- Don’t use disclaimers like “as an AI.” Stay human and confident.
-`;
+- Don't use disclaimers like "as an AI." Stay human and confident.`;
+
 export async function POST(req: NextRequest) {
-try {
-const { messages, lead } = await req.json();
-const apiKey = process.env.OPENAI_API_KEY;
-if (!apiKey) {
-return NextResponse.json({ error: "Missing OPENAI_API_KEY" }, { status:
-500 });
-}
-const body = {
-model: "gpt-5.1-mini", // fast + cost‑effective; adjust as needed
-messages: [
-{ role: "system", content: SYSTEM_PROMPT },
-// Inject lead/context if present so the bot can personalize
-lead ? { role: "system", content: `Lead context: ${JSON.stringify(lead)}
-` } : null,
-...messages,
-].filter(Boolean),
-temperature: 0.7,
-};
-const r = await fetch("https://api.openai.com/v1/chat/completions", {
-method: "POST",
-headers: {
-"Content-Type": "application/json",
-Authorization: `Bearer ${apiKey}`,
-},
-body: JSON.stringify(body),
-});
-if (!r.ok) {
-const t = await r.text();
-2
-return NextResponse.json({ error: t }, { status: 500 });
-}
-const data = await r.json();
-const text = data.choices?.[0]?.message?.content || "";
-return NextResponse.json({ reply: text });
-} catch (e: any) {
-return NextResponse.json({ error: e?.message || "Unknown error" }, {
-status: 500 });
-}
+  try {
+    const { messages, lead } = await req.json();
+
+    const apiKey = process.env.OPENAI_API_KEY;
+    if (!apiKey) {
+      return NextResponse.json(
+        { error: "Missing OPENAI_API_KEY" },
+        { status: 500 }
+      );
+    }
+
+    const requestBody = {
+      model: "gpt-5.1-mini",
+      messages: [
+        { role: "system", content: SYSTEM_PROMPT },
+        lead
+          ? {
+              role: "system",
+              content: `Lead context: ${JSON.stringify(lead)}`,
+            }
+          : null,
+        ...(Array.isArray(messages) ? messages : []),
+      ].filter(Boolean),
+      temperature: 0.7,
+    };
+
+    const response = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify(requestBody),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      return NextResponse.json({ error: errorText }, { status: 500 });
+    }
+
+    const data = await response.json();
+    const text = data.choices?.[0]?.message?.content ?? "";
+
+    return NextResponse.json({ reply: text });
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Unknown error";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
 }


### PR DESCRIPTION
## Summary
- rewrite the chat route prompt with clean formatting and remove stray characters that broke the build
- guard against non-array message payloads and improve error reporting when calling OpenAI

## Testing
- npm install *(fails: registry returned 403 Forbidden for scoped packages)*

------
https://chatgpt.com/codex/tasks/task_e_68e0e7ebb83883218010a4e19d021ef9